### PR TITLE
Added support for extra parameters in FinnaClient.search()

### DIFF
--- a/finna_client.py
+++ b/finna_client.py
@@ -76,7 +76,7 @@ class FinnaClient:
 
     def search(self, lookfor="", search_type=FinnaSearchType.AllFields,
         fields=None, filters=None, facets=None, facetFilters=None, sort=None,
-        page=None, limit=None, lng=None):
+        page=None, limit=None, lng=None, other=None):
         """Perform a Finna search and return the search results."""
         
         if not isinstance(search_type, FinnaSearchType):
@@ -102,6 +102,8 @@ class FinnaClient:
             if not isinstance(lng, FinnaLanguage):
                 raise ValueError('lng must be a valid FinnaLanguage')
             payload['lng'] = lng.value
+        if other is not None:
+            payload.update(other)
         
         req = requests.get(self.api_base + 'search', params=payload)
         req.raise_for_status()


### PR DESCRIPTION
There seem to be additional (undocumented?) parameters that can be added to search requests, that are not supported by FinnaClient.search(): one example is the "search_daterange_mv_type=within" parameter that restricts date range searches to those that lie completely within the specified range.

This change adds an non-specific "other" parameter (dictionary), that is added to the request. This can be used as follows:

```
from finna_client import FinnaClient

finna = FinnaClient()

finna.search('photo', 
             filters=['search_daterange_mv:"[1950 TO 1951]"',],
             other={'search_daterange_mv_type':'within'},
             limit=5)
```
